### PR TITLE
fixed out of date gemspec

### DIFF
--- a/street_address.gemspec
+++ b/street_address.gemspec
@@ -3,9 +3,10 @@ $LOAD_PATH.unshift 'lib'
 require 'street_address'
 
 Gem::Specification.new do |s|
-  s.name = "StreetAddress"
+  s.name = "street_address"
   s.licenses = ['MIT']
   s.version = StreetAddress::US::VERSION
+  s.platform = Gem::Platform::CURRENT
   s.date = Time.now.strftime('%Y-%m-%d')
   s.summary = "Parse Addresses into substituent parts. This gem includes US only."
   s.authors = ["Derrek Long"]


### PR DESCRIPTION
This is just updating the library to the standard Ruby gemspec syntax. I snakecased the name and added a platform check.

I'd be happy to help maintain this if it's needed/nobody's doing it. A lightweight, non-machine learning-based Ruby address parsing library is really helpful stuff.