### PR TITLE
Add case where sometimes addresses are located at highway merges and the merge is indicated in the address.

### DIFF
--- a/lib/street_address.rb
+++ b/lib/street_address.rb
@@ -763,9 +763,14 @@ module StreetAddress
 
         def to_address(input, args)
           # strip off some punctuation and whitespace
-          input.values.each { |string|
-            string.strip!
-            string.gsub!(/[^\w\s\-\#\&]/, '')
+          input.each_key { |k|
+            input[k].strip!
+
+            if k != "street"
+              input[k].gsub!(/[^\w\s\-\#\&]/, '')
+            else
+              input[k].gsub!(/[^\w\s\-\#\&\/]/, '')
+            end
           }
 
           input['redundant_street_type'] = false

--- a/test/address_test.rb
+++ b/test/address_test.rb
@@ -134,6 +134,10 @@ class AddressTest < MiniTest::Test
     "44 Canal Center Plaza Suite 500, Alexandria, VA 22314" => {
       :line1 => "44 Canal Center Plz Suite 500",
       :line2 => "Alexandria, VA 22314"
+    },
+    "11081 N State Highway 27/77, Hayward, WI 54843" => {
+      :line1 => "11081 N State Highway 27/77",
+      :line2 => "Hayward, WI 54843"
     }
   }
 


### PR DESCRIPTION
We've never actually seen address formatted this way, but it appears to actually be valid according to Pub 28: `11081 N State Highway 27/77, Hayward, WI 54843`

As is, StreetAddress::US is converting the output to: `11081 N State Highway 2777, Hayward, WI 54843`. We are expecting: `11081 N State Highway 27/77, Hayward, WI 54843`. PR includes fix and test case.