### PR TITLE
\s required since regular space is ignored in x-mode

### DIFF
--- a/lib/street_address.rb
+++ b/lib/street_address.rb
@@ -663,7 +663,7 @@ module StreetAddress
     self.address_regexp = /
       \A
       [^\w\x23]*    # skip non-word chars except # (eg unit)
-      #{number_regexp} \W*
+      #{number_regexp}\s\W* # \s required since regular space is ignored in x-mode
       (?:#{fraction_regexp}\W*)?
       #{street_regexp}\W+
       (?:#{unit_regexp}\W+)?


### PR DESCRIPTION
Addresses issue: https://github.com/street-address-rb/street-address/issues/48