### PR TITLE
name the captured fraction and add the captured fraction into address…

### DIFF
--- a/lib/street_address.rb
+++ b/lib/street_address.rb
@@ -556,7 +556,7 @@ module StreetAddress
     }
 
     self.street_type_regexp = Regexp.new(STREET_TYPES_LIST.keys.join("|"), Regexp::IGNORECASE)
-    self.fraction_regexp = /\d+\/\d+/
+    self.fraction_regexp = /(?<fraction>\d+\/\d+)/
     self.state_regexp = Regexp.new(
       '\b' + STATE_CODES.flatten.map{ |code| Regexp.quote(code) }.join("|") + '\b',
       Regexp::IGNORECASE
@@ -766,10 +766,16 @@ module StreetAddress
         end
 
         def to_address(input, args)
+          # append fraction to number before punctuation cleanup
+          if input['fraction'] && input['number']
+            input['number'] = "#{input['number']} #{input['fraction']}"
+            input.delete('fraction')
+          end
+
           # strip off some punctuation and whitespace
           input.values.each { |string|
             string.strip!
-            string.gsub!(/[^\w\s\-\#\&]/, '')
+            string.gsub!(/[^\w\s\-\#\&\/]/, '')
           }
 
           input['redundant_street_type'] = false

--- a/test/address_test.rb
+++ b/test/address_test.rb
@@ -102,7 +102,7 @@ class AddressTest < Minitest::Test
       :line2 => "Minneapolis, MN"
     },
     "3813 1/2 Some Road, Los Angeles, CA" => {
-      :line1 => "3813 Some Rd",
+      :line1 => "3813 1/2 Some Rd",
       :line2 => "Los Angeles, CA"
     },
     "1 First St, e San Jose CA" => {

--- a/test/street_address_test.rb
+++ b/test/street_address_test.rb
@@ -208,11 +208,19 @@ class StreetAddressUsTest < Minitest::Test
       :prefix => 'SE'
     },
     "3813 1/2 Some Road, Los Angeles, CA" => {
-      :number => '3813',
+      :number => '3813 1/2',
       :street => 'Some',
       :state => 'CA',
       :city => 'Los Angeles',
       :street_type => 'Rd',
+    },
+    "123 1/2 Main St, New York, NY 10001" => { # fractional house number (USPS Pub 28)
+      :number => '123 1/2',
+      :street => 'Main',
+      :street_type => 'St',
+      :city => 'New York',
+      :state => 'NY',
+      :postal_code => '10001'
     },
     "1 First St, e San Jose CA" => { # lower case city direction
       :number => '1',


### PR DESCRIPTION
related to #43 

This change handles addresses like:

> 33 1/2 Main St, Nashville, TN, 37069

such that the 1/2 is not discarded in the to_s or otherwise recomposed addresses after parsing.

It does end up handling the hwy 22/27 case as well.  